### PR TITLE
Fix: newVersions configuration is not visible

### DIFF
--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/UpdateVersionsPlugin.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/UpdateVersionsPlugin.java
@@ -53,7 +53,7 @@ public final class UpdateVersionsPlugin implements Plugin<Project> {
                                 conf -> {
                                     conf.setCanBeResolved(false);
                                     conf.setCanBeConsumed(true);
-                                    conf.setVisible(true);
+                                    conf.setVisible(false);
                                 });
 
         project.getArtifacts()

--- a/gradle-versions/src/test/groovy/com/markelliot/gradle/versions/UpdateVersionsPluginIntegrationSpec.groovy
+++ b/gradle-versions/src/test/groovy/com/markelliot/gradle/versions/UpdateVersionsPluginIntegrationSpec.groovy
@@ -36,5 +36,9 @@ class UpdateVersionsPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted('projectA:checkNewVersions')
 
         !versionsProps.text.contains("2.12.1")
+
+        def buildResult = runTasksSuccessfully('build')
+        !buildResult.wasExecuted(':checkNewVersions')
+        !buildResult.wasExecuted('projectA:checkNewVersions')
     }
 }


### PR DESCRIPTION
Workaround https://github.com/gradle/gradle/issues/6875 which causes all outgoing artifacts to be wired to assemble. By making configuration not visible it will not be resolved upon `build` (which triggers `assemble`)