### PR TITLE
Filter same version results at the source

### DIFF
--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/UpdateVersionsPropsTask.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/UpdateVersionsPropsTask.java
@@ -44,13 +44,8 @@ public abstract class UpdateVersionsPropsTask extends DefaultTask {
         updateRecs.forEach((k, v) -> versionsProps.update(k, v).ifPresent(updates::add));
         versionsProps.to(versionPropsFile);
 
-        Set<VersionsProps.UpdatedLine> filtered =
-                updates.stream()
-                        .filter(u -> !u.oldVersion().equals(u.newVersion()))
-                        .collect(Collectors.toCollection(LinkedHashSet::new));
-
         // markdown output
-        if (!filtered.isEmpty()) {
+        if (!updates.isEmpty()) {
             Reports.appendMarkdownReport(
                     getProject().getBuildDir(),
                     "## Updated Dependencies\n"

--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/props/VersionsProps.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/props/VersionsProps.java
@@ -67,6 +67,10 @@ public final class VersionsProps {
             if (line.type() == LineType.Version) {
                 VersionLine versionLine = (VersionLine) line;
                 if (versionLine.identifier().equals(bestMatch)) {
+                    if (versionLine.version().equals(version)) {
+                        // found best match but version is already what we expect
+                        return Optional.empty();
+                    }
                     System.out.printf("Setting %s = %s\n", bestMatch, version);
                     lines.set(
                             i,

--- a/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
+++ b/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
@@ -22,7 +22,6 @@ import com.google.common.base.Splitter;
 import com.markelliot.gradle.versions.props.VersionsProps;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 
 final class VersionsPropsTests {
@@ -49,9 +48,7 @@ final class VersionsPropsTests {
 
     @Test
     public void testNoUpdateForSameValue() {
-        VersionsProps props =
-                VersionsProps.from(
-                        List.of("com.foo.bar:qux = 1.2"));
+        VersionsProps props = VersionsProps.from(List.of("com.foo.bar:qux = 1.2"));
 
         Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "1.2");
         assertThat(updates).isEmpty();

--- a/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
+++ b/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.base.Splitter;
 import com.markelliot.gradle.versions.props.VersionsProps;
 import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 final class VersionsPropsTests {
@@ -43,5 +45,15 @@ final class VersionsPropsTests {
         assertThat(lines)
                 .contains("org.slf4j:* = 1.7.24")
                 .contains("org.slf4j:slf4j-api = 1.7.26 # bar");
+    }
+
+    @Test
+    public void testNoUpdateForSameValue() {
+        VersionsProps props =
+                VersionsProps.from(
+                        List.of("com.foo.bar:qux = 1.2"));
+
+        Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "1.2");
+        assertThat(updates).isEmpty();
     }
 }


### PR DESCRIPTION
Resolve a problem where we would produce update lines in Markdown that showed `oldVersion -> newVersion` for the same `oldVersion` and `newVersion` values.