### PR TITLE
Update disallowed qualifier check to be case insensitive

### DIFF
--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/CheckNewVersionsTask.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/CheckNewVersionsTask.java
@@ -178,7 +178,8 @@ public abstract class CheckNewVersionsTask extends DefaultTask {
     }
 
     private boolean containsDisallowedQualifier(String version) {
-        return DISALLOWED_QUALIFIERS.stream().anyMatch(version::contains);
+        String lowerCaseVersion = version.toLowerCase();
+        return DISALLOWED_QUALIFIERS.stream().anyMatch(lowerCaseVersion::contains);
     }
 
     private Configuration getResolvableCopy(Configuration config) {


### PR DESCRIPTION
Sometimes qualifiers are uppercase, but they're not getting rejected because we only check lowercase.