### PR TITLE
Adding capability to ignore particular lines in the version.props

### DIFF
--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/props/VersionsProps.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/props/VersionsProps.java
@@ -24,6 +24,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -54,6 +55,8 @@ public final class VersionsProps {
         this.resolver = resolver;
     }
 
+    private static final String IGNORE_MARKER = "versions:ignore";
+
     public Optional<UpdatedLine> update(String identifier, String version) {
         Optional<String> maybeMatch = resolver.patternFor(identifier);
         if (maybeMatch.isEmpty()) {
@@ -67,6 +70,10 @@ public final class VersionsProps {
             if (line.type() == LineType.Version) {
                 VersionLine versionLine = (VersionLine) line;
                 if (versionLine.identifier().equals(bestMatch)) {
+                    if (shouldIgnore(versionLine)) {
+                        System.out.printf("Skipping %s (marked with versions:ignore)\n", bestMatch);
+                        return Optional.empty();
+                    }
                     if (versionLine.version().equals(version)) {
                         // found best match but version is already what we expect
                         return Optional.empty();
@@ -90,6 +97,12 @@ public final class VersionsProps {
         }
 
         return Optional.empty();
+    }
+
+    private static boolean shouldIgnore(VersionLine line) {
+        return line.comment()
+                .map(comment -> comment.toLowerCase(Locale.ROOT).contains(IGNORE_MARKER))
+                .orElse(false);
     }
 
     public String writeToString() {

--- a/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
+++ b/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
@@ -97,4 +97,3 @@ final class VersionsPropsTests {
         assertThat(lines).contains("com.foo.bar:qux = 2.0 # some other comment");
     }
 }
-

--- a/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
+++ b/gradle-versions/src/test/java/com/markelliot/gradle/versions/VersionsPropsTests.java
@@ -53,4 +53,48 @@ final class VersionsPropsTests {
         Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "1.2");
         assertThat(updates).isEmpty();
     }
+
+    @Test
+    public void testIgnoreMarkerPreventsUpdate() {
+        VersionsProps props =
+                VersionsProps.from(List.of("com.foo.bar:qux = 1.2 # versions:ignore"));
+
+        Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "2.0");
+        assertThat(updates).isEmpty();
+
+        List<String> lines = Splitter.on('\n').splitToList(props.writeToString());
+        assertThat(lines).contains("com.foo.bar:qux = 1.2 # versions:ignore");
+    }
+
+    @Test
+    public void testIgnoreMarkerWithOtherCommentText() {
+        VersionsProps props =
+                VersionsProps.from(
+                        List.of("com.foo.bar:qux = 1.2 # using beta, versions:ignore for now"));
+
+        Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "2.0");
+        assertThat(updates).isEmpty();
+    }
+
+    @Test
+    public void testIgnoreMarkerCaseInsensitive() {
+        VersionsProps props =
+                VersionsProps.from(List.of("com.foo.bar:qux = 1.2 # VERSIONS:IGNORE"));
+
+        Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "2.0");
+        assertThat(updates).isEmpty();
+    }
+
+    @Test
+    public void testWithoutIgnoreMarkerStillUpdates() {
+        VersionsProps props =
+                VersionsProps.from(List.of("com.foo.bar:qux = 1.2 # some other comment"));
+
+        Optional<VersionsProps.UpdatedLine> updates = props.update("com.foo.bar:qux", "2.0");
+        assertThat(updates).isPresent();
+
+        List<String> lines = Splitter.on('\n').splitToList(props.writeToString());
+        assertThat(lines).contains("com.foo.bar:qux = 2.0 # some other comment");
+    }
 }
+

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,11 @@ This plugin restricts updates such that:
 * Recommended versions do not contain `alpha` or `beta` in the version string.
 * Recommended versions may have empty status metadata or the status must be `release`
 
+To skip updates for a specific dependency, add `versions:ignore` to the line comment in `versions.props`:
+```properties
+com.company:foo = 1.2.3 # versions:ignore
+```
+
 License
 -------
 This repository is subject to the [Apache 2.0 License](LICENSE).


### PR DESCRIPTION
## Problem Statement
We have a few instances of open source projects we use where, for whatever reason, the latest versions are all on a BETA build and there has not been a non-BETA build in quite some time. Therefore, we want to ignore those lines in the `version.props` and only update them manually.

## Solution
This allows a developer to simply add a comment inline to the `version.props` that tells the plugin to not upgrade the versions for that line, even if one is available. It will print an output stating that it is skipping the line, and move on. 