### PR TITLE
Pin nebula-test to <12 until Gradle 9 upgrade

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,12 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "automergeStrategy": "squash"
+  "automergeStrategy": "squash",
+  "packageRules": [
+    {
+      "description": "nebula-test 12 requires Gradle 9; staying on 11.x until the Gradle upgrade lands",
+      "matchPackageNames": ["com.netflix.nebula:nebula-test"],
+      "allowedVersions": "<12"
+    }
+  ]
 }


### PR DESCRIPTION
nebula-test v12 baselines Gradle 9 and Groovy 4. Adopting it on Gradle 8.14 fails at runtime with `NoSuchMethodError: groovy.lang.IntRange.<init>(boolean, boolean, int, int)` because v12 is compiled against Groovy 4 but Gradle 8 ships Groovy 3.

Upgrading to Gradle 9 also breaks `org.inferred.processors` (removed `convention` API), so the upgrade is larger than a single dependency bump. Pin to <12 until that work is scheduled.

Closes #305.