### PR TITLE
support gradle 9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     id("com.google.cloud.tools.jib") version "3.5.3" apply false
     id("com.palantir.consistent-versions") version "3.16.0"
     id("net.ltgt.errorprone") version "5.1.0" apply false
-    id("org.inferred.processors") version "3.7.0" apply false
 }
 
 version = "git describe --tags".runCommand().trim() +
@@ -52,7 +51,6 @@ allprojects {
 
     plugins.withType<JavaLibraryPlugin> {
         apply(plugin = "net.ltgt.errorprone")
-        apply(plugin = "org.inferred.processors")
 
         dependencies {
             "errorprone"("com.google.errorprone:error_prone_core")

--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/CheckNewVersionsTask.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/CheckNewVersionsTask.java
@@ -65,6 +65,7 @@ public abstract class CheckNewVersionsTask extends DefaultTask {
                         // make safe for use with gradle-consistent-versions
                         .filter(config -> !config.getName().startsWith("consistentVersions"))
                         .filter(config -> !config.getName().equals("unifiedClasspath"))
+                        .filter(Configuration::isCanBeResolved)
                         .collect(
                                 Collectors.toMap(
                                         Configuration::getName, this::getRecsForConfiguration));
@@ -192,7 +193,7 @@ public abstract class CheckNewVersionsTask extends DefaultTask {
         LenientConfiguration lenientConfig =
                 config.getResolvedConfiguration().getLenientConfiguration();
         Set<ResolvedDependency> moduleDeps =
-                lenientConfig.getFirstLevelModuleDependencies(Specs.SATISFIES_ALL);
+                lenientConfig.getFirstLevelModuleDependencies();
         Map<String, ResolvedDependency> resolvedDeps = new HashMap<>();
         moduleDeps.forEach(
                 dep -> resolvedDeps.put(dep.getModuleGroup() + ":" + dep.getModuleName(), dep));

--- a/gradle-versions/src/main/java/com/markelliot/gradle/versions/CheckNewVersionsTask.java
+++ b/gradle-versions/src/main/java/com/markelliot/gradle/versions/CheckNewVersionsTask.java
@@ -22,6 +22,7 @@ import com.markelliot.gradle.versions.api.UpdateReport;
 import com.markelliot.gradle.versions.api.YamlSerDe;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,7 +34,6 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -179,7 +179,7 @@ public abstract class CheckNewVersionsTask extends DefaultTask {
     }
 
     private boolean containsDisallowedQualifier(String version) {
-        String lowerCaseVersion = version.toLowerCase();
+        String lowerCaseVersion = version.toLowerCase(Locale.ROOT);
         return DISALLOWED_QUALIFIERS.stream().anyMatch(lowerCaseVersion::contains);
     }
 
@@ -192,8 +192,7 @@ public abstract class CheckNewVersionsTask extends DefaultTask {
     private Map<String, ResolvedDependency> getResolvedVersions(Configuration config) {
         LenientConfiguration lenientConfig =
                 config.getResolvedConfiguration().getLenientConfiguration();
-        Set<ResolvedDependency> moduleDeps =
-                lenientConfig.getFirstLevelModuleDependencies();
+        Set<ResolvedDependency> moduleDeps = lenientConfig.getFirstLevelModuleDependencies();
         Map<String, ResolvedDependency> resolvedDeps = new HashMap<>();
         moduleDeps.forEach(
                 dep -> resolvedDeps.put(dep.getModuleGroup() + ":" + dep.getModuleName(), dep));

--- a/gradle-versions/src/test/java/com/markelliot/gradle/versions/UpdateGradleWrapperTaskTests.java
+++ b/gradle-versions/src/test/java/com/markelliot/gradle/versions/UpdateGradleWrapperTaskTests.java
@@ -15,18 +15,22 @@ final class UpdateGradleWrapperTaskTests {
     @Test
     public void testUpdateDistributionUrl() {
         String original =
-                "distributionBase=GRADLE_USER_HOME\n"
-                        + "distributionPath=wrapper/dists\n"
-                        + "distributionUrl=https\\://services.gradle.org/distributions/gradle-7.2-bin.zip\n"
-                        + "zipStoreBase=GRADLE_USER_HOME\n"
-                        + "zipStorePath=wrapper/dists\n";
+                """
+                distributionBase=GRADLE_USER_HOME
+                distributionPath=wrapper/dists
+                distributionUrl=https\\://services.gradle.org/distributions/gradle-7.2-bin.zip
+                zipStoreBase=GRADLE_USER_HOME
+                zipStorePath=wrapper/dists
+                """;
 
         String desired =
-                "distributionBase=GRADLE_USER_HOME\n"
-                        + "distributionPath=wrapper/dists\n"
-                        + "distributionUrl=https\\://services.gradle.org/distributions/gradle-7.3-bin.zip\n"
-                        + "zipStoreBase=GRADLE_USER_HOME\n"
-                        + "zipStorePath=wrapper/dists\n";
+                """
+                distributionBase=GRADLE_USER_HOME
+                distributionPath=wrapper/dists
+                distributionUrl=https\\://services.gradle.org/distributions/gradle-7.3-bin.zip
+                zipStoreBase=GRADLE_USER_HOME
+                zipStorePath=wrapper/dists
+                """;
 
         assertThat(
                         UpdateGradleWrapperTask.updateDistributionUrl(

--- a/gradle-versions/src/test/java/com/markelliot/gradle/versions/api/DependencyUpdateRecTests.java
+++ b/gradle-versions/src/test/java/com/markelliot/gradle/versions/api/DependencyUpdateRecTests.java
@@ -9,7 +9,11 @@ final class DependencyUpdateRecTests {
     void test_handleEmptyCurrentVersion() {
         DependencyUpdateRec rec =
                 YamlSerDe.deserialize(
-                        "group: group\n" + "name: name\n" + "latestVersion: latestVersion\n",
+                        """
+                        group: group
+                        name: name
+                        latestVersion: latestVersion
+                        """,
                         DependencyUpdateRec.class);
 
         assertThat(rec.currentVersion()).isNullOrEmpty();


### PR DESCRIPTION
Handful of changes to support gradle 9:

* Remove `org.inferred.processors` plugin which does not run on gradle 9 and is replaced by `annotationProcessor` configurations
* Replace `getFirstLevelModuleDependencies(Spec<? super Dependency> dependencySpec)` which is not allowed in gradle 9 with the no-arg version -- the behavior should be the same since we were passing `Specs.SATISFIES_ALL` instead of something more restrictive
* Skip non-resolvable configurations; without that, we were getting `copyRecursive() is not allowed for configuration 'api'` errors

Tested with both gradle 9.6.1 and gradle 8.14.5 and from what I can tell this works with both, so should not be a breaking change for 8.x users.